### PR TITLE
Fix firebase url parse

### DIFF
--- a/lib/src/setter_functions.dart
+++ b/lib/src/setter_functions.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
-import 'package:ringtone_set/ringtone_set.dart';
 
 const MethodChannel _channel = const MethodChannel('ringtone_set');
 
@@ -38,7 +37,12 @@ Future<bool> setFromNetwork({
     storageDirectoryType: _getStorageDirectoryType(action),
   );
   final file = File(path);
-  final response = await http.get(Uri.parse(Uri.encodeFull(url)));
+
+  // Firebase files are returned with encoding. Double encoding
+  // will cause an error.
+  final uri = Uri.tryParse(url) ?? Uri.parse(Uri.encodeFull(url));
+
+  final response = await http.get(uri);
   if (response.statusCode == 200) {
     await file.writeAsBytes(response.bodyBytes);
     final mimeType = await _parseMimeType(response);

--- a/lib/src/setter_functions.dart
+++ b/lib/src/setter_functions.dart
@@ -34,7 +34,7 @@ Future<bool> setFromNetwork({
   required String action,
 }) async {
   final path = await _getPath(
-    src: url,
+    src: url.hashCode.toString(),
     storageDirectoryType: _getStorageDirectoryType(action),
   );
   final file = File(path);

--- a/lib/src/setter_functions.dart
+++ b/lib/src/setter_functions.dart
@@ -38,7 +38,7 @@ Future<bool> setFromNetwork({
     storageDirectoryType: _getStorageDirectoryType(action),
   );
   final file = File(path);
-  final response = await http.get(Uri.parse(url));
+  final response = await http.get(Uri.parse(Uri.encodeFull(url)));
   if (response.statusCode == 200) {
     await file.writeAsBytes(response.bodyBytes);
     final mimeType = await _parseMimeType(response);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  lint: 2.0.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Firebase files are returned with encoding. Double encoding will cause an error. Fix it.